### PR TITLE
Remove popup WIP Text

### DIFF
--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -18,7 +18,7 @@ const Popup = () => {
         {/*</div>*/}
       </div>
       <div className="w-[28rem]">
-        <div className="p-6">WIP</div>
+        <div className="p-6">The Codecov Browser Extension is currently in Beta. Issues and feedback are welcome at <a href="https://github.com/codecov/codecov-browser-extension/issues"> https://github.com/codecov/codecov-browser-extension/issues </a>  </div>
       </div>
     </div>
   );

--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -18,7 +18,16 @@ const Popup = () => {
         {/*</div>*/}
       </div>
       <div className="w-[28rem]">
-        <div className="p-6">The Codecov Browser Extension is currently in Beta. Issues and feedback are welcome at <a href="https://github.com/codecov/codecov-browser-extension/issues"> https://github.com/codecov/codecov-browser-extension/issues </a>  </div>
+        <div className="p-6">
+          The Codecov Browser Extension is currently in Beta. Issues and
+          feedback are welcome at{" "}
+          <a
+            href="https://github.com/codecov/codecov-browser-extension/issues"
+            target="_blank"
+          >
+            https://github.com/codecov/codecov-browser-extension/issues{" "}
+          </a>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Currently the popup for the extension in browser only provides a WIP. The plan is to make this area more robust in the future, but for now I've updated it to link to our Issues page.