### PR TITLE
Add GitHub Actions workflow to publish extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+on:
+  workflow_dispatch:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: npm ci
+      - run: npm run build
+      - run: |
+          cp dist dist-firefox
+          cp dist-firefox/manifest.firefox.json dist-firefox/manifest.json
+      - name: Publish to Chrome
+        working-directory: dist
+        run: npx chrome-webstore-upload-cli@2 upload --auto-publish
+        env:
+          EXTENSION_ID: "gedikamndpbemklijjkncpnolildpbgo"
+          CLIENT_ID: ${{ secrets.GOOGLE_WEB_STORE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.GOOGLE_WEB_STORE_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.GOOGLE_WEB_STORE_REFRESH_TOKEN }}
+      - name: Publish to Firefox
+        working-directory: dist-firefox
+        run: npx web-ext-submit@7
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_JWT_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_JWT_SECRET }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Codecov for GitHub
+### Codecov for GitHub
 
 <img width="1912" alt="image" src="https://user-images.githubusercontent.com/44864521/213549217-bed0071c-c5bc-4a12-944f-31ce15648ab7.png">
 
@@ -9,3 +9,27 @@ $ web-ext run -s dist -t chromium
 **Note**: You must be on GitHub's new UI for this extension to perform its magic. ✨  
 
 As of today, GitHub will show you the old UI if not logged in (running in a temporary profile using web-ext).
+
+---
+
+#### Build Instructions
+
+These steps will build the extension in the `dist/` folder.
+
+MacOS 13.3.1 (22E261)  
+NodeJS version 19.8.1
+
+Chrome
+
+```sh
+$ npm install
+$ npm run build
+```
+
+Firefox
+
+```sh
+$ npm install
+$ npm run build
+$ cp dist/manifest.firefox.json dist/manifest.json
+```

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": 3,
+
+  "name": "Codecov",
+  "description": "Codecov Browser Extension",
+  "version": "0.1.0",
+
+  "options_ui": {
+    "page": "options.html"
+  },
+
+  "action": {
+    "default_icon": "codecov-circle.png",
+    "default_popup": "popup.html"
+  },
+
+  "content_scripts": [
+    {
+      "matches": ["*://github.com/*"],
+      "js": ["js/vendor.js", "js/githubFile.js", "js/githubPR.js"]
+    }
+  ],
+
+  "background": {
+    "scripts": ["js/background.js"]
+  },
+
+  "permissions": ["storage"],
+
+  "host_permissions": ["https://api.codecov.io/*"],
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{f3924b0d-e29f-4593-b605-084b3d71ed9d}"
+    }
+  }
+}


### PR DESCRIPTION
Can be triggered manually, builds and publishes extension to Chrome and Firefox addons stores.