### PR TITLE
Add Dedicated and Self-Hosted Setup Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Pre-requisites:
 How to enable: Click your avatar at the top-right of a GitHub page and select “Feature preview”. Then select “Global navigation update” and click the Enable button located at the top right of the modal.
 The extension uses your logged-in session to determine what private repos you have access to. Please make sure to log in to Codecov using your web browser to view coverage data for private repos in GitHub,
 
+## Use with Self-Hosted and Dedicated Cloud Versions of Codecov
+You can use this extension against installations of Codecov and GitHub that are:
+
+* Self-hosted
+* Part of Codecov's Dedicated Cloud plan
+
+In order to do so you must provide:
+
+* The URL of the Codecov installation
+* The URL of your GitHub installation (even if that url is just https://github.com)
+* [An API token for Codecov](https://docs.codecov.com/reference/overview)
+
+You can provide this information by using the Settings menu for the Extension in your browser. 
 
 ## Running Locally
 ```sh


### PR DESCRIPTION
Adds Documentation on how to use extension with Dedicated and Self-Hosted installations.

This should be merged after merging #33 