### PR TITLE
Self hosted service auth check URL update

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -12,7 +12,7 @@ import {
 
 export class Codecov {
   static baseUrl = "https://api.codecov.io";
-  static checkAuthPath = "/api/v2/github/codecov";
+  static checkAuthPath = "/api/v2/github/";
 
   static _init() {
     fetchIntercept.register({


### PR DESCRIPTION
fixes #64

Dropping the username from the path seems to be sufficient to get me past the block.

![image](https://github.com/codecov/codecov-browser-extension/assets/5386503/ec2d3ec8-7721-4575-8f24-29fd3a0f7c32)
