### PR TITLE
fix: Non-virtualized file lines not targetted by extension

### DIFF
--- a/src/content/github/file/main.tsx
+++ b/src/content/github/file/main.tsx
@@ -17,6 +17,7 @@ import {
   componentsStorageKey,
   flagsStorageKey,
   lineSelector,
+  noVirtLineSelector,
 } from "./utils/constants";
 import {
   animateAndAnnotateLines,
@@ -228,6 +229,7 @@ async function process(metadata: FileMetadata): Promise<void> {
 
   globals.coverageReport = coverageReport;
   animateAndAnnotateLines(lineSelector, annotateLine);
+  animateAndAnnotateLines(noVirtLineSelector, annotateLine);
 }
 
 async function promptPastReport(metadata: FileMetadata): Promise<void> {
@@ -275,6 +277,7 @@ function createCoverageButton() {
     const isInactive = codecovButton.getAttribute("data-inactive");
     if (isInactive == "true") {
       animateAndAnnotateLines(lineSelector, annotateLine);
+      animateAndAnnotateLines(noVirtLineSelector, annotateLine);
       codecovButton.removeAttribute("data-inactive");
       codecovButton.style.opacity = "1";
     } else {
@@ -325,7 +328,15 @@ function updateButton(text: string) {
 }
 
 function annotateLine(line: HTMLElement) {
-  const lineNumber = parseInt(line.getAttribute("data-key")!) + 1;
+  let lineNumber = _.parseInt(line.getAttribute("data-key")!) + 1;
+  const lineNumberString = line.getAttribute("data-key");
+  if (lineNumberString) {
+    lineNumber = _.parseInt(lineNumberString) + 1; // Virtualized lines have data-key="{number - 1}"
+  } else {
+    const noVirtLineNumberString = line.getAttribute("id");
+    if (!noVirtLineNumberString) return;
+    lineNumber = _.parseInt(noVirtLineNumberString.slice(2)); // Non-virtualized lines have id="LC{number}"
+  }
   // called from "Coverage: N/A" button on-click handler
   if (!globals.coverageReport) {
     return;

--- a/src/content/github/file/utils/constants.ts
+++ b/src/content/github/file/utils/constants.ts
@@ -1,3 +1,4 @@
 export const lineSelector = ".react-code-line-contents";
+export const noVirtLineSelector = ".react-code-line-contents-no-virtualization"
 export const flagsStorageKey = "selected_flags";
 export const componentsStorageKey = "selected_components";


### PR DESCRIPTION
Fixes bug where non-virtualized line lists were not being targetted properly by the extension. Non-virtualized lines seem to only happen for me when logged in to GitHub, logged out gives virtualized lines. My theory is they're testing some new code here lol.

This has been tested for both Firefox and Chrome in both logged in and out states.

Closes https://github.com/codecov/feedback/issues/425
