### PR TITLE
fix: Remove codecov owner from selfhosted auth check

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -12,7 +12,7 @@ import {
 
 export class Codecov {
   static baseUrl = "https://api.codecov.io";
-  static checkAuthPath = "/api/v2/github/codecov";
+  static checkAuthPath = "/api/v2/github/";
 
   static _init() {
     fetchIntercept.register({


### PR DESCRIPTION
Updates auth check API endpoint to fix a bug where self-hosted codecov instances are not able to be added due to the requirement for the 'codecov' user to be present.

Closes https://github.com/codecov/codecov-browser-extension/issues/64
