### PR TITLE
fix: Coverage not clearing on file navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "watch": "webpack --config webpack/webpack.dev.js --watch",
     "build": "webpack --config webpack/webpack.prod.js",
+    "build.firefox": "npm run build && mv dist/manifest.firefox.json dist/manifest.json",
     "lint": "prettier --write \"src/**/*.{ts,tsx}\""
   },
   "author": "",

--- a/src/content/github/file/main.tsx
+++ b/src/content/github/file/main.tsx
@@ -33,7 +33,6 @@ import {
 } from "../common/fetchers";
 import { print } from "src/utils";
 import Sentry from "../../common/sentry";
-import { isFileUrl } from "../common/utils";
 
 const globals: {
   coverageReport?: FileCoverageReport;
@@ -375,6 +374,7 @@ function clearElements() {
 
 function clearAnimationAndAnnotations() {
   clearAnimation(lineSelector, annotateLine);
+  clearAnimation(noVirtLineSelector, annotateLine);
   clearAnnotations((line: HTMLElement) => {
     line.style.backgroundColor = "inherit";
   });


### PR DESCRIPTION
Fixes a bug where on navigating between files, coverage highlights were not clearing and updating.

Closes https://github.com/codecov/codecov-browser-extension/issues/108
