### PR TITLE
feat: Cache flags and components for one hour

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,12 @@
-export const codecovApiTokenStorageKey = "self_hosted_codecov_api_token"; // Keeping this key to not break existing installs.
+export const codecovApiTokenStorageKey = "self_hosted_codecov_api_token";
 export const selfHostedCodecovURLStorageKey = "self_hosted_codecov_url";
 export const selfHostedGitHubURLStorageKey = "self_hosted_github_url";
 export const dynamicContentScriptRegistrationId = "dynamic-content-script";
 
 export const codecovCloudApiUrl = "https://api.codecov.io";
 export const githubCloudUrl = "https://github.com";
+
+export const cacheTtlMs = 1000 * 60 * 60; // 1 hour
 
 export const providers = {
   github: "github",


### PR DESCRIPTION
This PR adds a caching layer to the background service worker for the flags and components fetchers. The cache just uses localstorage and will start with a one hour TTL.

Closes https://github.com/codecov/codecov-browser-extension/issues/110
