### PR TITLE
ref: Build to ESM for tree shaking

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 comment:
   require_bundle_changes: True
-  bundle_change_threshold: "1Kb"
+  bundle_change_threshold: "0b"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+comment:
+  require_bundle_changes: True
+  bundle_change_threshold: "1Kb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@sentry/browser": "^8.37.1",
+        "@sentry/browser": "^9.1.0",
         "clsx": "^1.2.1",
         "code-tag": "^1.1.0",
         "color-alpha": "^1.1.3",
@@ -907,61 +907,53 @@
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.37.1.tgz",
-      "integrity": "sha512-OSR/V5GCsSCG7iapWtXCT/y22uo3HlawdEgfM1NIKk1mkP15UyGQtGEzZDdih2H+SNuX1mp9jQLTjr5FFp1A5w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.1.0.tgz",
+      "integrity": "sha512-S1uT+kkFlstWpwnaBTIJSwwAID8PS3aA0fIidOjNezeoUE5gOvpsjDATo9q+sl6FbGWynxMz6EnYSrq/5tuaBQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry/core": "9.1.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.37.1.tgz",
-      "integrity": "sha512-Se25NXbSapgS2S+JssR5YZ48b3OY4UGmAuBOafgnMW91LXMxRNWRbehZuNUmjjHwuywABMxjgu+Yp5uJDATX+g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.1.0.tgz",
+      "integrity": "sha512-jTDCqkqH3QDC8m9WO4mB06hqnBRsl3p7ozoh0E774UvNB6blOEZjShhSGMMEy5jbbJajPWsOivCofUtFAwbfGw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry/core": "9.1.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.37.1.tgz",
-      "integrity": "sha512-E/Plhisk/pXJjOdOU12sg8m/APTXTA21iEniidP6jW3/+O0tD/H/UovEqa4odNTqxPMa798xHQSQNt5loYiaLA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.1.0.tgz",
+      "integrity": "sha512-E2xrUoms90qvm0BVOuaZ8QfkMoTUEgoIW/35uOeaqNcL7uOIj8c5cSEQQKit2Dr7CL6W+Ci5c6Khdyd5C0NL5w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.37.1",
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry-internal/browser-utils": "9.1.0",
+        "@sentry/core": "9.1.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.37.1.tgz",
-      "integrity": "sha512-1JLAaPtn1VL5vblB0BMELFV0D+KUm/iMGsrl4/JpRm0Ws5ESzQl33DhXVv1IX/ZAbx9i14EjR7MG9+Hj70tieQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.1.0.tgz",
+      "integrity": "sha512-gxredVe+mOgfNqDJ3dTLiRON3FK1rZ8d0LHp7TICK/umLkWFkuso0DbNeyKU+3XCEjCr9VM7ZRqTDMzmY6zyVg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "8.37.1",
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry-internal/replay": "9.1.0",
+        "@sentry/core": "9.1.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
@@ -974,21 +966,19 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.37.1.tgz",
-      "integrity": "sha512-5ym+iGiIpjIKKpMWi9S3/tXh9xneS+jqxwRTJqed3cb8i4ydfMAAP8sM3U8xMCWWABpWyIUW+fpewC0tkhE1aQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.1.0.tgz",
+      "integrity": "sha512-G55e5j77DqRW3LkalJLAjRRfuyKrjHaKTnwIYXa6ycO+Q1+l14pEUxu+eK5Abu2rtSdViwRSb5/G6a/miSUlYA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.37.1",
-        "@sentry-internal/feedback": "8.37.1",
-        "@sentry-internal/replay": "8.37.1",
-        "@sentry-internal/replay-canvas": "8.37.1",
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry-internal/browser-utils": "9.1.0",
+        "@sentry-internal/feedback": "9.1.0",
+        "@sentry-internal/replay": "9.1.0",
+        "@sentry-internal/replay-canvas": "9.1.0",
+        "@sentry/core": "9.1.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
@@ -1201,37 +1191,12 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.37.1.tgz",
-      "integrity": "sha512-82csXby589iDupM3VgCHJeWZagUyEEaDnbFcoZ/Z91QX2Sjq8FcF5OsforoXjw09i0XTFqlkFAnQVpDBmMXcpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.37.1.tgz",
-      "integrity": "sha512-ryMOTROLSLINKFEbHWvi7GigNrsQhsaScw2NddybJGztJQ5UhxIGESnxGxWCufBmWFDwd7+5u0jDPCVUJybp7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.1.0.tgz",
+      "integrity": "sha512-djWEzSBpMgqdF3GQuxO+kXCUX+Mgq42G4Uah/HSUBvPDHKipMmyWlutGRoFyVPPOnCDgpHu3wCt83wbpEyVmDw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.37.1.tgz",
-      "integrity": "sha512-Qtn2IfpII12K17txG/ZtTci35XYjYi4CxbQ3j7nXY7toGv/+MqPXwV5q2i9g94XaSXlE5Wy9/hoCZoZpZs/djA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "8.37.1"
-      },
-      "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/webpack-plugin": {
@@ -5251,45 +5216,37 @@
       }
     },
     "@sentry-internal/browser-utils": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.37.1.tgz",
-      "integrity": "sha512-OSR/V5GCsSCG7iapWtXCT/y22uo3HlawdEgfM1NIKk1mkP15UyGQtGEzZDdih2H+SNuX1mp9jQLTjr5FFp1A5w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.1.0.tgz",
+      "integrity": "sha512-S1uT+kkFlstWpwnaBTIJSwwAID8PS3aA0fIidOjNezeoUE5gOvpsjDATo9q+sl6FbGWynxMz6EnYSrq/5tuaBQ==",
       "requires": {
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry/core": "9.1.0"
       }
     },
     "@sentry-internal/feedback": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.37.1.tgz",
-      "integrity": "sha512-Se25NXbSapgS2S+JssR5YZ48b3OY4UGmAuBOafgnMW91LXMxRNWRbehZuNUmjjHwuywABMxjgu+Yp5uJDATX+g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.1.0.tgz",
+      "integrity": "sha512-jTDCqkqH3QDC8m9WO4mB06hqnBRsl3p7ozoh0E774UvNB6blOEZjShhSGMMEy5jbbJajPWsOivCofUtFAwbfGw==",
       "requires": {
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry/core": "9.1.0"
       }
     },
     "@sentry-internal/replay": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.37.1.tgz",
-      "integrity": "sha512-E/Plhisk/pXJjOdOU12sg8m/APTXTA21iEniidP6jW3/+O0tD/H/UovEqa4odNTqxPMa798xHQSQNt5loYiaLA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.1.0.tgz",
+      "integrity": "sha512-E2xrUoms90qvm0BVOuaZ8QfkMoTUEgoIW/35uOeaqNcL7uOIj8c5cSEQQKit2Dr7CL6W+Ci5c6Khdyd5C0NL5w==",
       "requires": {
-        "@sentry-internal/browser-utils": "8.37.1",
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry-internal/browser-utils": "9.1.0",
+        "@sentry/core": "9.1.0"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.37.1.tgz",
-      "integrity": "sha512-1JLAaPtn1VL5vblB0BMELFV0D+KUm/iMGsrl4/JpRm0Ws5ESzQl33DhXVv1IX/ZAbx9i14EjR7MG9+Hj70tieQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.1.0.tgz",
+      "integrity": "sha512-gxredVe+mOgfNqDJ3dTLiRON3FK1rZ8d0LHp7TICK/umLkWFkuso0DbNeyKU+3XCEjCr9VM7ZRqTDMzmY6zyVg==",
       "requires": {
-        "@sentry-internal/replay": "8.37.1",
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry-internal/replay": "9.1.0",
+        "@sentry/core": "9.1.0"
       }
     },
     "@sentry/babel-plugin-component-annotate": {
@@ -5299,17 +5256,15 @@
       "dev": true
     },
     "@sentry/browser": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.37.1.tgz",
-      "integrity": "sha512-5ym+iGiIpjIKKpMWi9S3/tXh9xneS+jqxwRTJqed3cb8i4ydfMAAP8sM3U8xMCWWABpWyIUW+fpewC0tkhE1aQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.1.0.tgz",
+      "integrity": "sha512-G55e5j77DqRW3LkalJLAjRRfuyKrjHaKTnwIYXa6ycO+Q1+l14pEUxu+eK5Abu2rtSdViwRSb5/G6a/miSUlYA==",
       "requires": {
-        "@sentry-internal/browser-utils": "8.37.1",
-        "@sentry-internal/feedback": "8.37.1",
-        "@sentry-internal/replay": "8.37.1",
-        "@sentry-internal/replay-canvas": "8.37.1",
-        "@sentry/core": "8.37.1",
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
+        "@sentry-internal/browser-utils": "9.1.0",
+        "@sentry-internal/feedback": "9.1.0",
+        "@sentry-internal/replay": "9.1.0",
+        "@sentry-internal/replay-canvas": "9.1.0",
+        "@sentry/core": "9.1.0"
       }
     },
     "@sentry/bundler-plugin-core": {
@@ -5428,26 +5383,9 @@
       "optional": true
     },
     "@sentry/core": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.37.1.tgz",
-      "integrity": "sha512-82csXby589iDupM3VgCHJeWZagUyEEaDnbFcoZ/Z91QX2Sjq8FcF5OsforoXjw09i0XTFqlkFAnQVpDBmMXcpQ==",
-      "requires": {
-        "@sentry/types": "8.37.1",
-        "@sentry/utils": "8.37.1"
-      }
-    },
-    "@sentry/types": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.37.1.tgz",
-      "integrity": "sha512-ryMOTROLSLINKFEbHWvi7GigNrsQhsaScw2NddybJGztJQ5UhxIGESnxGxWCufBmWFDwd7+5u0jDPCVUJybp7w=="
-    },
-    "@sentry/utils": {
-      "version": "8.37.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.37.1.tgz",
-      "integrity": "sha512-Qtn2IfpII12K17txG/ZtTci35XYjYi4CxbQ3j7nXY7toGv/+MqPXwV5q2i9g94XaSXlE5Wy9/hoCZoZpZs/djA==",
-      "requires": {
-        "@sentry/types": "8.37.1"
-      }
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.1.0.tgz",
+      "integrity": "sha512-djWEzSBpMgqdF3GQuxO+kXCUX+Mgq42G4Uah/HSUBvPDHKipMmyWlutGRoFyVPPOnCDgpHu3wCt83wbpEyVmDw=="
     },
     "@sentry/webpack-plugin": {
       "version": "2.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@sentry/browser": "^9.1.0",
         "clsx": "^1.2.1",
         "code-tag": "^1.1.0",
-        "color-alpha": "^1.1.3",
         "dom-chef": "^5.1.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
@@ -44,7 +43,7 @@
         "tailwindcss": "^3.2.7",
         "ts-loader": "^8.0.0",
         "tsconfig-paths-webpack-plugin": "^4.0.1",
-        "typescript": "^4.4.3 ",
+        "typescript": "^5.7.3",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.0.0",
         "webpack-merge": "^5.0.0"
@@ -1900,14 +1899,6 @@
         "url": "https://github.com/sponsors/fregante"
       }
     },
-    "node_modules/color-alpha": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.1.3.tgz",
-      "integrity": "sha512-krPYBO1RSO5LH4AGb/b6z70O1Ip2o0F0+0cVFN5FN99jfQtZFT08rQyg+9oOBNJYAn3SRwJIFC8jUEOKz7PisA==",
-      "dependencies": {
-        "color-parse": "^1.4.1"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1923,15 +1914,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
-      "dependencies": {
-        "color-name": "^1.0.0"
-      }
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -4176,16 +4160,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {
@@ -5960,14 +5945,6 @@
       "resolved": "https://registry.npmjs.org/code-tag/-/code-tag-1.1.0.tgz",
       "integrity": "sha512-qqvyRC9Fmnqy/1nK2Jz6FIk6F24nliVIVtQFg0r7PuZCZHfWO/c7eZHVlPxFKRSnOSIUUf/jrF1FG8j67FinPg=="
     },
-    "color-alpha": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.1.3.tgz",
-      "integrity": "sha512-krPYBO1RSO5LH4AGb/b6z70O1Ip2o0F0+0cVFN5FN99jfQtZFT08rQyg+9oOBNJYAn3SRwJIFC8jUEOKz7PisA==",
-      "requires": {
-        "color-parse": "^1.4.1"
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5980,15 +5957,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
-      "requires": {
-        "color-name": "^1.0.0"
-      }
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "colorette": {
       "version": "1.4.0",
@@ -7629,9 +7599,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     },
     "undici": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@sentry/browser": "^9.1.0",
     "clsx": "^1.2.1",
     "code-tag": "^1.1.0",
-    "color-alpha": "^1.1.3",
     "dom-chef": "^5.1.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
@@ -47,7 +46,7 @@
     "tailwindcss": "^3.2.7",
     "ts-loader": "^8.0.0",
     "tsconfig-paths-webpack-plugin": "^4.0.1",
-    "typescript": "^4.4.3 ",
+    "typescript": "^5.7.3",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.0.0",
     "webpack-merge": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.3.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@sentry/browser": "^8.37.1",
+    "@sentry/browser": "^9.1.0",
     "clsx": "^1.2.1",
     "code-tag": "^1.1.0",
     "color-alpha": "^1.1.3",

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -1,5 +1,9 @@
 import browser from "webextension-polyfill";
-import * as Sentry from "@sentry/browser";
+import {
+  init as sentryInit,
+  browserTracingIntegration,
+  startSpan,
+} from "@sentry/browser";
 
 import { MessageType } from "src/types";
 import { Codecov } from "src/service";
@@ -11,12 +15,12 @@ import {
 async function main(): Promise<void> {
   browser.runtime.onMessage.addListener(handleMessages);
 
-  Sentry.init({
+  sentryInit({
     // @ts-ignore SENTRY_DSN is populated by Webpack at build time
     dsn: SENTRY_DSN,
 
     integrations: [
-      Sentry.browserTracingIntegration({
+      browserTracingIntegration({
         // disable automatic span creation
         instrumentNavigation: false,
         instrumentPageLoad: false,
@@ -33,7 +37,7 @@ async function handleMessages(message: {
   referrer?: string;
 }) {
   const codecov = new Codecov();
-  return Sentry.startSpan({ name: message.type }, async () => {
+  return startSpan({ name: message.type }, async () => {
     switch (message.type) {
       case MessageType.FETCH_COMMIT_REPORT:
         return codecov.fetchCommitReport(message.payload, message.referrer!);

--- a/src/content/common/sentry.ts
+++ b/src/content/common/sentry.ts
@@ -1,33 +1,35 @@
 import {
+  breadcrumbsIntegration,
+  browserApiErrorsIntegration,
   BrowserClient,
   defaultStackParser,
-  getDefaultIntegrations,
+  globalHandlersIntegration,
   makeFetchTransport,
+  dedupeIntegration,
   Scope,
-} from '@sentry/browser';
+} from "@sentry/browser";
 
 // Sentry config
-// Browser extensions must initialize Sentry a bit differently to avoid 
+// Browser extensions must initialize Sentry a bit differently to avoid
 // conflicts between Sentry instances should the site the extension is running
 // on also use Sentry. Read more here:
 // https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/
-
-const sentryIntegrations = getDefaultIntegrations({}).filter(defaultIntegration => {
-  return !['BrowserApiErrors', 'TryCatch', 'Breadcrumbs', 'GlobalHandlers'].includes(
-    defaultIntegration.name
-  );
-});
 
 const sentryClient = new BrowserClient({
   // @ts-ignore SENTRY_DSN is populated by Webpack at build time
   dsn: SENTRY_DSN,
   transport: makeFetchTransport,
   stackParser: defaultStackParser,
-  integrations: sentryIntegrations,
+  integrations: [
+    breadcrumbsIntegration,
+    browserApiErrorsIntegration,
+    globalHandlersIntegration,
+    dedupeIntegration,
+  ],
 });
 
 const Sentry = new Scope();
 Sentry.setClient(sentryClient);
 sentryClient.init();
 
-export default Sentry
+export default Sentry;

--- a/src/content/github/common/constants.ts
+++ b/src/content/github/common/constants.ts
@@ -7,7 +7,10 @@ export const animationAttachmentId = `${animationName}-attachment`;
 export const seenClassName = "codecov-seen-mark";
 
 export const colors = {
+  redAlpha: "rgba(245,32,32,0.25)",
+  greenAlpha: "rgba(33,181,119,0.25)",
+  yellowAlpha: "rgba(244,176,27,0.25)",
   red: "rgb(245,32,32)",
   green: "rgb(33,181,119)",
-  yellow: "rgb(244,176,27)",
+  yellow: "rgba(244,176,27)",
 };

--- a/src/content/github/common/constants.ts
+++ b/src/content/github/common/constants.ts
@@ -12,5 +12,5 @@ export const colors = {
   yellowAlpha: "rgba(244,176,27,0.25)",
   red: "rgb(245,32,32)",
   green: "rgb(33,181,119)",
-  yellow: "rgba(244,176,27)",
+  yellow: "rgb(244,176,27)",
 };

--- a/src/content/github/file/main.tsx
+++ b/src/content/github/file/main.tsx
@@ -1,5 +1,4 @@
 import browser from "webextension-polyfill";
-import alpha from "color-alpha";
 import Drop from "tether-drop";
 import _ from "lodash";
 import "tether-drop/dist/css/drop-theme-arrows.css";
@@ -353,11 +352,11 @@ function annotateLine(line: HTMLElement) {
   }
   const status = globals.coverageReport[lineNumber];
   if (status === CoverageStatus.COVERED) {
-    line.style.backgroundColor = alpha(colors.green, 0.25);
+    line.style.backgroundColor = colors.greenAlpha;
   } else if (status === CoverageStatus.UNCOVERED) {
-    line.style.backgroundColor = alpha(colors.red, 0.25);
+    line.style.backgroundColor = colors.redAlpha;
   } else if (status === CoverageStatus.PARTIAL) {
-    line.style.backgroundColor = alpha(colors.yellow, 0.25);
+    line.style.backgroundColor = colors.yellowAlpha;
   } else {
     line.style.backgroundColor = "inherit";
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "commonjs",
+    "module": "es6",
     "target": "es6",
     "esModuleInterop": true,
     "sourceMap": false,
@@ -15,6 +15,7 @@
     "outDir": "dist/js",
     "noEmitOnError": true,
     "jsx": "react",
-    "typeRoots": ["node_modules/@types"]
+    "typeRoots": ["node_modules/@types"],
+    "moduleResolution": "node"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "es6",
-    "target": "es6",
+    "module": "esnext",
+    "target": "esnext",
     "esModuleInterop": true,
     "sourceMap": false,
     "baseUrl": "./",
@@ -16,6 +16,6 @@
     "noEmitOnError": true,
     "jsx": "react",
     "typeRoots": ["node_modules/@types"],
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   }
 }


### PR DESCRIPTION
This PR changes updates our webpack config to use ESM instead of CJS modules so we can actually do tree shaking. The reason for this is our extension failed Chrome's review process due to some third party script loading code from the Sentry SDK. We don't actually use this code and it should be removed from our bundle with tree shaking.
