### PR TITLE
fix: Source archive upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,9 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.GOOGLE_WEB_STORE_REFRESH_TOKEN }}
       - name: Publish to Firefox
         working-directory: dist-firefox
-        run: npx web-ext sign --use-submission-api --channel listed
+        run: npx web-ext sign
         env:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_JWT_ISSUER }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_JWT_SECRET }}
+          WEB_EXT_CHANNEL: listed
           WEB_EXT_API_UPLOAD_SOURCE_CODE: codecov-browser-extension.tar.gz


### PR DESCRIPTION
Fix incorrect call to web-ext. They changed the api in version 8 and I was reading about version 7.
