### PR TITLE
fix: Run FOSSA check on main to fix "failling" status in README

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,8 +1,10 @@
 name: Enforce License Compliance
 
 on:
+  push:
+    branches: 
+      - main
   pull_request:
-    branches: [main, master]
 
 jobs:
   enforce-license-compliance:


### PR DESCRIPTION
Noticed licence status in the README was "failing". Poking around revealed our license compliance is good, but we're just not running the check on main. This PR resolves that.
