### PR TITLE
feat: Add basic data consent dialog

### DIFF
--- a/src/content/github/common/consent.ts
+++ b/src/content/github/common/consent.ts
@@ -1,0 +1,28 @@
+import { consentStorageKey, consentDialogCopy } from "./constants";
+
+export async function ensureConsent(
+  { checkOnly }: { checkOnly: boolean } = { checkOnly: false }
+) {
+  let consent: boolean = await chrome.storage.local
+    .get(consentStorageKey)
+    .then((res) => res[consentStorageKey]);
+
+  if (consent) {
+    return;
+  }
+
+  if (!checkOnly) {
+    consent = window.confirm(consentDialogCopy);
+  }
+
+  if (!consent) {
+    throw new Error("Codecov extension data collection consent not given.");
+  }
+
+  const storageObject: { [id: string]: boolean } = {};
+  storageObject[consentStorageKey] = consent;
+
+  chrome.storage.local.set(storageObject);
+
+  return Promise.resolve();
+}

--- a/src/content/github/common/constants.ts
+++ b/src/content/github/common/constants.ts
@@ -1,3 +1,9 @@
+// The version number here should represent the last version where consent requirement was updated.
+// We must update the key's version to re-request consent whenever the data we collect changes.
+export const consentStorageKey = "codecov-consent-0.5.9";
+export const consentDialogCopy =
+  "By clicking OK, you are authorizing the Codecov browser extension to collect your IP address and the URLs you visit on domains you've given the extension access to. Declining this will prevent the extension from working. For more information see the Privacy Policy in the Codecov extension store listing.";
+
 export const animationName = "codecov-gh-observer";
 
 export const animationDefinitionId = `${animationName}-keyframe`;

--- a/src/content/github/file/main.tsx
+++ b/src/content/github/file/main.tsx
@@ -32,6 +32,7 @@ import {
 } from "../common/fetchers";
 import { print } from "src/utils";
 import Sentry from "../../common/sentry";
+import { ensureConsent } from "../common/consent";
 
 const globals: {
   coverageReport?: FileCoverageReport;
@@ -59,6 +60,7 @@ function init(): Promise<void> {
 
 async function main(): Promise<void> {
   try {
+    await ensureConsent();
     const urlMetadata = getMetadataFromURL();
     if (!urlMetadata) {
       print("file not detected at current URL");

--- a/src/content/github/pr/main.tsx
+++ b/src/content/github/pr/main.tsx
@@ -1,5 +1,4 @@
 import React from "dom-chef";
-import browser from "webextension-polyfill";
 import _ from "lodash";
 
 import "src/basscss.css";
@@ -16,6 +15,7 @@ import { print } from "src/utils";
 import { getPRReport } from "../common/fetchers";
 import { isPrUrl } from "../common/utils";
 import Sentry from "src/content/common/sentry";
+import { ensureConsent } from "../common/consent";
 
 const globals: {
   coverageReport?: PullCoverageReport;
@@ -23,6 +23,7 @@ const globals: {
 
 async function main() {
   try {
+    await ensureConsent({ checkOnly: true });
     document.addEventListener("soft-nav:end", execute);
     await execute();
   } catch (e) {


### PR DESCRIPTION
Adds a basic data consent dialog. If consent is not given, the extension will not run and it will continue to show the popup on subsequent github page loads until consent is given or the app is uninstalled.
