### PR TITLE
ci(publish): Correct source code environment variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,5 +62,5 @@ jobs:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_JWT_ISSUER }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_JWT_SECRET }}
           WEB_EXT_CHANNEL: listed
-          WEB_EXT_API_UPLOAD_SOURCE_CODE: ../codecov-browser-extension-${{ github.event.release.tag_name }}.tar.gz
+          WEB_EXT_UPLOAD_SOURCE_CODE: ../codecov-browser-extension-${{ github.event.release.tag_name }}.tar.gz
           WEB_EXT_APPROVAL_TIMEOUT: 0 # Disable timeout for approval


### PR DESCRIPTION
The `web-ext` documentation stated the incorrect environment variable for uploading source code: https://github.com/mozilla/web-ext/issues/3452