### PR TITLE
fix: Large FOSSA badge link and GitHub Action

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,7 +2,7 @@ name: Enforce License Compliance
 
 on:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
 
@@ -10,7 +10,7 @@ jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Enforce License Compliance'
-        uses: getsentry/action-enforce-license-compliance@57ba820387a1a9315a46115ee276b2968da51f3d # main
+      - name: "Enforce License Compliance"
+        uses: getsentry/action-enforce-license-compliance@main
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ $ npm run build:firefox
 
 ## License
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fcodecov%2Fcodecov-browser-extension.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fcodecov%2Fcodecov-browser-extension?ref=badge_large)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B29430%2Fgithub.com%2Fcodecov%2Fcodecov-browser-extension.svg?type=large&issueType=license)](https://app.fossa.com/projects/custom%2B29430%2Fgithub.com%2Fcodecov%2Fcodecov-browser-extension?ref=badge_large&issueType=license)


### PR DESCRIPTION
The FOSSA badge currently links to an old commit from when the project was linked via GitHub instead of uploaded via the CLI. This commit fixes the link to show the correct information. I also changed the target to main for the license compliance action.