### PR TITLE
feat: Add telemetry opt-in/out buttons to consent page

### DIFF
--- a/public/consent.html
+++ b/public/consent.html
@@ -46,7 +46,7 @@
 
       button {
         width: 214px;
-        height: 49px;
+        height: 75px;
         border-radius: 4px;
         border-width: 1px;
         padding-top: 4px;
@@ -67,11 +67,14 @@
         cursor: pointer;
       }
 
+      button + button {
+        margin-left: 10px;
+      }
+
       button#codecov-uninstall {
         background: white;
         border: 1px solid black;
         color: black;
-        margin-left: 10px;
       }
     </style>
   </head>
@@ -102,7 +105,12 @@
         The Codecov extension may collect and use information from your browser
         such as your IP address and the URLs of the pages you access on
         https://github.com or on an enterprise version or self-hosted
-        installation of Github you explicitly grant the extension access to.
+        installation of GitHub to which you explicitly grant the extension
+        access.
+      </p>
+      <p>
+        Additionally, you may choose to opt-in or opt-out of non-personal
+        telemetry collection (error reporting and performance data).
       </p>
       <p>
         By clicking 'Accept', you confirm that you understand and agree to the
@@ -110,7 +118,10 @@
         to accept, please note that the extension will not work.
       </p>
       <br />
-      <button id="codecov-consent-accept">Accept</button>
+      <button id="codecov-consent-accept">Accept and allow telemetry</button>
+      <button id="codecov-consent-accept-essential">
+        Accept and opt-out of telemetry
+      </button>
       <button id="codecov-uninstall">Uninstall</button>
     </div>
   </body>

--- a/public/consent.js
+++ b/public/consent.js
@@ -3,11 +3,30 @@ document.addEventListener("DOMContentLoaded", function () {
   consentButton.addEventListener("click", async function () {
     const result = await browser.runtime.sendMessage({
       type: "set_consent",
-      payload: true,
+      payload: "all",
     });
 
     if (result) {
-      console.log("Consent granted, closing tab");
+      console.log("All consent granted, closing tab");
+      close();
+    } else {
+      console.error(
+        "Something went wrong saving consent. Please report this at https://github.com/codecov/codecov-browser-extension/issues"
+      );
+    }
+  });
+
+  var essentialConsentButton = document.getElementById(
+    "codecov-consent-accept-essential"
+  );
+  essentialConsentButton.addEventListener("click", async function () {
+    const result = await browser.runtime.sendMessage({
+      type: "set_consent",
+      payload: "essential",
+    });
+
+    if (result) {
+      console.log("Essential consent granted, closing tab");
       close();
     } else {
       console.error(

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -14,7 +14,7 @@ import {
 
 async function handleConsent(): Promise<void> {
   const consent = await new Codecov().getConsent();
-  if (!consent) {
+  if (consent === "none") {
     const url = browser.runtime.getURL("consent.html");
     await browser.tabs.create({ url, active: true });
   }
@@ -41,8 +41,8 @@ async function handleMessages(message: {
   referrer?: string;
 }) {
   const codecov = new Codecov();
-  if (await codecov.getConsent()) {
-    console.log("Have data consent, initializing Sentry");
+  if ((await codecov.getConsent()) === "all") {
+    console.log("Have full data consent, initializing Sentry");
     sentryInit({
       dsn: process.env.SENTRY_DSN,
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 // The version number here should represent the last version where consent requirement was updated.
 // We must update the key's version to re-request consent whenever the data we collect changes.
-export const consentStorageKey = "codecov-consent-0.5.9";
+export const allConsentStorageKey = "codecov-consent-0.6.3";
+export const onlyEssentialConsentStorageKey = "codecov-essential-consent-0.6.3";
 
 export const codecovApiTokenStorageKey = "self_hosted_codecov_api_token";
 export const selfHostedCodecovURLStorageKey = "self_hosted_codecov_url";

--- a/src/content/common/sentry.ts
+++ b/src/content/common/sentry.ts
@@ -8,6 +8,7 @@ import {
   dedupeIntegration,
   Scope,
 } from "@sentry/browser";
+import { Consent } from "src/types";
 
 // Sentry config
 // Browser extensions must initialize Sentry a bit differently to avoid
@@ -15,20 +16,26 @@ import {
 // on also use Sentry. Read more here:
 // https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/
 
-const sentryClient = new BrowserClient({
-  dsn: process.env.SENTRY_DSN,
-  transport: makeFetchTransport,
-  stackParser: defaultStackParser,
-  integrations: [
-    breadcrumbsIntegration,
-    browserApiErrorsIntegration,
-    globalHandlersIntegration,
-    dedupeIntegration,
-  ],
-});
+export function initSentry(consent: Consent): Scope | undefined {
+  // Only enable Sentry if have "all" data consent.
+  if (consent !== "all") {
+    return undefined;
+  }
 
-const Sentry = new Scope();
-Sentry.setClient(sentryClient);
-sentryClient.init();
+  const sentryClient = new BrowserClient({
+    dsn: process.env.SENTRY_DSN,
+    transport: makeFetchTransport,
+    stackParser: defaultStackParser,
+    integrations: [
+      breadcrumbsIntegration,
+      browserApiErrorsIntegration,
+      globalHandlersIntegration,
+      dedupeIntegration,
+    ],
+  });
 
-export default Sentry;
+  const Sentry = new Scope();
+  Sentry.setClient(sentryClient);
+  sentryClient.init();
+  return Sentry;
+}

--- a/src/content/github/common/fetchers.ts
+++ b/src/content/github/common/fetchers.ts
@@ -1,5 +1,6 @@
 import browser from "webextension-polyfill";
 import {
+  Consent,
   FileCoverageReportResponse,
   FileMetadata,
   MessageType,
@@ -102,7 +103,7 @@ export async function getPRReport(url: any) {
   return response.data;
 }
 
-export async function getConsent() {
+export async function getConsent(): Promise<Consent> {
   const response = await browser.runtime.sendMessage({
     type: MessageType.GET_CONSENT,
   });

--- a/src/content/github/file/main.tsx
+++ b/src/content/github/file/main.tsx
@@ -60,13 +60,13 @@ async function init(): Promise<void> {
   // TODO: this event is not fired when navigating using the browser's back and forward buttons
   document.addEventListener("soft-nav:end", () => {
     clear();
-    main(consent);
+    main();
   });
 
-  return main(consent);
+  return main();
 }
 
-async function main(consent: Consent): Promise<void> {
+async function main(): Promise<void> {
   try {
     if (consent === "none") {
       // No data consent, do nothing.
@@ -325,7 +325,7 @@ async function handleFlagClick(selectedFlags: string[]) {
     [flagsStorageKey]: selectedFlags,
   });
   clear();
-  await main(consent);
+  await main();
 }
 
 async function handleComponentClick(selectedComponents: string[]) {
@@ -336,7 +336,7 @@ async function handleComponentClick(selectedComponents: string[]) {
     [componentsStorageKey]: selectedComponents,
   });
   clear();
-  await main(consent);
+  await main();
 }
 
 function calculateCoveragePct(coverageReport: FileCoverageReport): number {

--- a/src/content/github/pr/main.tsx
+++ b/src/content/github/pr/main.tsx
@@ -30,10 +30,10 @@ async function init(): Promise<void> {
 
   Sentry = initSentry(consent);
 
-  return main(consent);
+  return main();
 }
 
-async function main(consent: Consent) {
+async function main() {
   try {
     if (consent === "none") {
       // No data consent, do nothing.

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,3 +41,5 @@ export enum MessageType {
   GET_CONSENT = "get_consent",
   SET_CONSENT = "set_consent",
 }
+
+export type Consent = "all" | "essential" | "none";


### PR DESCRIPTION
Another Mozilla requirement. Hopefully this is satisfactory.
