### PR TITLE
fix: Add lock to prevent double consent tab

### DIFF
--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -13,8 +13,11 @@ import {
 } from "./dynamic_content_scripts";
 
 async function handleConsent(): Promise<void> {
-  const consent = await new Codecov().getConsent();
-  if (consent === "none") {
+  const codecov = new Codecov();
+  const consent = await codecov.getConsent();
+  const canOpenConsentTab = await codecov.canOpenConsentTab();
+
+  if (consent === "none" && canOpenConsentTab) {
     const url = browser.runtime.getURL("consent.html");
     await browser.tabs.create({ url, active: true });
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@
 // We must update the key's version to re-request consent whenever the data we collect changes.
 export const allConsentStorageKey = "codecov-consent-0.6.3";
 export const onlyEssentialConsentStorageKey = "codecov-essential-consent-0.6.3";
+export const consentTabLock = "codecov-consent-tab-lock";
 
 export const codecovApiTokenStorageKey = "self_hosted_codecov_api_token";
 export const selfHostedCodecovURLStorageKey = "self_hosted_codecov_url";

--- a/src/service.ts
+++ b/src/service.ts
@@ -289,8 +289,8 @@ export class Codecov {
   }
 
   async canOpenConsentTab(): Promise<Boolean> {
-    // Returns whether the consent tab was opened this session. Resolves the
-    // case where two consent tabs are opened simultaneously.
+    // Returns false if the consent tab has been opened in the last two seconds.
+    // Resolves the case where two consent tabs are opened simultaneously.
     const locked = await browser.storage.local
       .get([consentTabLock])
       .then((res) => res[consentTabLock]);


### PR DESCRIPTION
The consent tab seems to be opening twice, once for update and once for install. This lock prevents that from happening.

Tested to make sure it probably won't have a race condition where both gets happen before the first set. It seems to work fine.